### PR TITLE
Кастомизация вывода пагинации в Ditto

### DIFF
--- a/assets/snippets/if/snippet.if.php
+++ b/assets/snippets/if/snippet.if.php
@@ -93,6 +93,8 @@ for ($i=1;$i<count($opers);$i++){
         $output = ($subject %$operand==0) ? true: false;$i++;
         break;
        
+				case 'pages':$output = ($subject != '[+pages+]') ? true : false;$i++;
+					break;  
 				case '!=':
 				case 'not':$output = ($subject != $operand) ? true: false;$i++;
 					break;


### PR DESCRIPTION
При пагинации выводятся ссылки на страницы. Если всего одна страница, то ничего не выводится. Стандартными средствами сниппета 'if' проверить количество страниц нельзя. 
Чтобы можно было изменять внешний вид выводимого списка, к примеру выводить слово "Страницы" перед ссылками, добавлен оператор 'pages'. Он проверяет правильно проверяет есть ли пагинация у Ditto. 
