### PR TITLE
Fix OnFileBrowserUpload

### DIFF
--- a/manager/media/browser/mcpuk/core/browser.php
+++ b/manager/media/browser/mcpuk/core/browser.php
@@ -616,7 +616,7 @@ class browser extends uploader {
         
         $modx->invokeEvent('OnFileBrowserUpload',array(
             'filepath'=>realpath($dir),
-            'filename'=>$filename
+            'filename'=>str_replace("$dir/","",realpath($target))
         ));
         
         $this->makeThumb($target);


### PR DESCRIPTION
Для существующего файла в событие отправлялось его имя до переименования.
