### PR TITLE
Issue 183

### DIFF
--- a/install/setup.sql
+++ b/install/setup.sql
@@ -1011,6 +1011,8 @@ REPLACE INTO `{PREFIX}system_eventnames`
 ('89','OnManagerPageInit','2',''),
 ('90','OnWebPageInit','5',''),
 ('101','OnLoadDocumentObject','5',''),
+('104','OnBeforeLoadDocumentObject','5',''),
+('105','OnAfterLoadDocumentObject','5',''),
 ('91','OnLoadWebDocument','5',''),
 ('92','OnParseDocument','5',''),
 ('93','OnManagerLoginFormRender','2',''),

--- a/manager/includes/document.parser.class.inc.php
+++ b/manager/includes/document.parser.class.inc.php
@@ -1400,66 +1400,80 @@ class DocumentParser {
             $method = 'id';
             $identifier = $this->documentListing[$identifier];
         }
-        // get document groups for current user
-        if ($docgrp= $this->getUserDocGroups())
-            $docgrp= implode(",", $docgrp);
-        // get document
-        $access= ($this->isFrontend() ? "sc.privateweb=0" : "1='" . $_SESSION['mgrRole'] . "' OR sc.privatemgr=0") .
-         (!$docgrp ? "" : " OR dg.document_group IN ($docgrp)");
-        $result= $this->db->select(
-			'sc.*',
-			"{$tblsc} sc
-				LEFT JOIN {$tbldg} dg ON dg.document = sc.id",
-			"sc.{$method} = '{$identifier}' AND ({$access})",
-			"",
-			1);
-        $rowCount= $this->db->getRecordCount($result);
-        if ($rowCount < 1) {
-            if ($this->config['unauthorized_page']) {
-                // method may still be alias, while identifier is not full path alias, e.g. id not found above
-                if ($method === 'alias') {
-                    $secrs = $this->db->select('count(dg.id)', "{$tbldg} as dg, {$tblsc} as sc", "dg.document = sc.id AND sc.alias = '{$identifier}'", '', 1);
-                } else {
-                    $secrs = $this->db->select('count(id)', $tbldg, "document = '{$identifier}'", '', 1);
-                }
-                // check if file is not public
-                    $seclimit= $this->db->getValue($secrs);
-            }
-            if ($seclimit > 0) {
-                // match found but not publicly accessible, send the visitor to the unauthorized_page
-                $this->sendUnauthorizedPage();
-                exit; // stop here
-            } else {
-                $this->sendErrorPage();
-                exit;
-            }
-        }
 
-        # this is now the document :) #
-        $documentObject= $this->db->getRow($result);
-        if($isPrepareResponse==='prepareResponse') $this->documentObject = & $documentObject;
-        $this->invokeEvent('OnLoadDocumentObject');
-    	if ($documentObject['template']) {
-        // load TVs and merge with document - Orig by Apodigm - Docvars
-        $rs = $this->db->select(
-			"tv.*, IF(tvc.value!='',tvc.value,tv.default_text) as value",
-			$this->getFullTableName("site_tmplvars") . " tv 
-				INNER JOIN " . $this->getFullTableName("site_tmplvar_templates")." tvtpl ON tvtpl.tmplvarid = tv.id 
+		$out = $this->invokeEvent('OnBeforeLoadDocumentObject', compact('method', 'identifier', 'documentObject'));
+		if(is_array($out)){
+			$documentObject = $out;
+		}else{
+			// get document groups for current user
+			if ($docgrp= $this->getUserDocGroups()) $docgrp= implode(",", $docgrp);
+			// get document
+			$access= ($this->isFrontend() ? "sc.privateweb=0" : "1='" . $_SESSION['mgrRole'] . "' OR sc.privatemgr=0") .
+				(!$docgrp ? "" : " OR dg.document_group IN ($docgrp)");
+			$result= $this->db->select(
+				'sc.*',
+				"{$tblsc} sc
+				LEFT JOIN {$tbldg} dg ON dg.document = sc.id",
+				"sc.{$method} = '{$identifier}' AND ({$access})",
+				"",
+				1);
+			$rowCount= $this->db->getRecordCount($result);
+			if ($rowCount < 1) {
+				$seclimit = 0;
+				if ($this->config['unauthorized_page']) {
+					// method may still be alias, while identifier is not full path alias, e.g. id not found above
+					if ($method === 'alias') {
+						$secrs = $this->db->select('count(dg.id)', "{$tbldg} as dg, {$tblsc} as sc", "dg.document = sc.id AND sc.alias = '{$identifier}'", '', 1);
+					} else {
+						$secrs = $this->db->select('count(id)', $tbldg, "document = '{$identifier}'", '', 1);
+					}
+					// check if file is not public
+					$seclimit= $this->db->getValue($secrs);
+				}
+				if ($seclimit > 0) {
+					// match found but not publicly accessible, send the visitor to the unauthorized_page
+					$this->sendUnauthorizedPage();
+					exit; // stop here
+				} else {
+					$this->sendErrorPage();
+					exit;
+				}
+			}
+			# this is now the document :) #
+			$documentObject= $this->db->getRow($result);
+
+			if($isPrepareResponse==='prepareResponse') $this->documentObject = & $documentObject;
+			$out = $this->invokeEvent('OnLoadDocumentObject', compact('method', 'identifier', 'documentObject'));
+			if(is_array($out)){
+				$documentObject = $out;
+			}
+			if ($documentObject['template']) {
+				// load TVs and merge with document - Orig by Apodigm - Docvars
+				$rs = $this->db->select(
+					"tv.*, IF(tvc.value!='',tvc.value,tv.default_text) as value",
+					$this->getFullTableName("site_tmplvars") . " tv
+				INNER JOIN " . $this->getFullTableName("site_tmplvar_templates")." tvtpl ON tvtpl.tmplvarid = tv.id
 				LEFT JOIN " . $this->getFullTableName("site_tmplvar_contentvalues")." tvc ON tvc.tmplvarid=tv.id AND tvc.contentid = '{$documentObject['id']}'",
-			"tvtpl.templateid = '{$documentObject['template']}'"
-			);
-			$tmplvars = array();
-            while ($row= $this->db->getRow($rs)) {
-                $tmplvars[$row['name']]= array (
-                    $row['name'],
-                    $row['value'],
-                    $row['display'],
-                    $row['display_params'],
-                    $row['type']
-                );
-            }
-            $documentObject= array_merge($documentObject, $tmplvars);
+					"tvtpl.templateid = '{$documentObject['template']}'"
+				);
+				$tmplvars = array();
+				while ($row= $this->db->getRow($rs)) {
+					$tmplvars[$row['name']]= array (
+						$row['name'],
+						$row['value'],
+						$row['display'],
+						$row['display_params'],
+						$row['type']
+					);
+				}
+				$documentObject= array_merge($documentObject, $tmplvars);
+			}
+			$out = $this->invokeEvent('OnAfterLoadDocumentObject', compact('method', 'identifier', 'documentObject'));
+			if(is_array($out)){
+				$documentObject = $out;
+			}
 		}
+
         return $documentObject;
     }
 

--- a/manager/includes/document.parser.class.inc.php
+++ b/manager/includes/document.parser.class.inc.php
@@ -1401,7 +1401,7 @@ class DocumentParser {
             $identifier = $this->documentListing[$identifier];
         }
 
-		$out = $this->invokeEvent('OnBeforeLoadDocumentObject', compact('method', 'identifier', 'documentObject'));
+		$out = $this->invokeEvent('OnBeforeLoadDocumentObject', compact('method', 'identifier'));
 		if(is_array($out)){
 			$documentObject = $out;
 		}else{


### PR DESCRIPTION
#183 
В общем теперь можно вызвать метод **getDocumentObject()** с параметром $method отличным от id и alias, чтобы загрузить данные из какой-то своей таблицы при помощи плагина на событии **OnBeforeLoadDocumentObject**. Даже если оставить штатные значения параметров метода, то при помощи этого события можно упростить обязательные SQL запросы выкинув из них проверку принадлежности документа к группе. Или выкинуть редирект на 404 страницу, если вдруг запрошенного документа через метод **getDocumentObject** не оказалось (*например, в исходнике запрятался id*).

Аналогичным образом, можно дозагрузить данные в documentObject через событие **OnAfterLoadDocumentObject**. Это событие тоже добавлено специально, т.к. вдруг какая-то связь хранится в ТВ, которая может понадобиться в плагине.

Ну и собственно из-за чего все это затеивалось - событие **OnLoadDocumentObject**, как и 2 новых события (**OnBeforeLoadDocumentObject**, **OnAfterLoadDocumentObject**) теперь принимает новые аргументы **method**, **identifier** и текущее значение **documentObject**