### PR TITLE
Refactor get login user xxx

### DIFF
--- a/manager/includes/document.parser.class.inc.php
+++ b/manager/includes/document.parser.class.inc.php
@@ -3268,23 +3268,24 @@ class DocumentParser {
      * @return string
      */
     public function getLoginUserID($context= '') {
-		switch(true){
-			case (!empty($context) && is_scalar($context) && isset($_SESSION[$context . 'Validated'])):{
-				$out = $_SESSION[$context . 'InternalKey'];
-				break;
-			}
-			case ($this->isFrontend() && isset ($_SESSION['webValidated'])):{
-				$out = $_SESSION['webInternalKey'];
-				break;
-			}
-			case ($this->isBackend() && isset ($_SESSION['mgrValidated'])):{
-				$out = $_SESSION['mgrInternalKey'];
-				break;
-			}
-			default:{
-				$out = false;
-			}
-		}
+        $out = false;
+
+        if(!empty($context)){
+            if(is_scalar($context) && isset($_SESSION[$context . 'Validated'])){
+                $out = $_SESSION[$context . 'InternalKey'];
+            }
+        }else{
+    		switch(true){
+    			case ($this->isFrontend() && isset ($_SESSION['webValidated'])):{
+    				$out = $_SESSION['webInternalKey'];
+    				break;
+    			}
+    			case ($this->isBackend() && isset ($_SESSION['mgrValidated'])):{
+    				$out = $_SESSION['mgrInternalKey'];
+    				break;
+    			}
+    		}
+        }
 		return $out;
     }
 
@@ -3295,15 +3296,25 @@ class DocumentParser {
      * @return string
      */
     function getLoginUserName($context= '') {
-        if (!empty($context) && isset ($_SESSION[$context . 'Validated'])) {
-            return $_SESSION[$context . 'Shortname'];
+        $out = false;
+
+        if(!empty($context)){
+            if(is_scalar($context) && isset($_SESSION[$context . 'Validated'])){
+                $out = $_SESSION[$context . 'Shortname'];
+            }
+        }else{
+            switch(true){
+                case ($this->isFrontend() && isset ($_SESSION['webValidated'])):{
+                    $out = $_SESSION['webShortname'];
+                    break;
+                }
+                case ($this->isBackend() && isset ($_SESSION['mgrValidated'])):{
+                    $out = $_SESSION['mgrShortname'];
+                    break;
+                }
+            }
         }
-        elseif ($this->isFrontend() && isset ($_SESSION['webValidated'])) {
-            return $_SESSION['webShortname'];
-        }
-        elseif ($this->isBackend() && isset ($_SESSION['mgrValidated'])) {
-            return $_SESSION['mgrShortname'];
-        }
+        return $out;
     }
 
    /**


### PR DESCRIPTION
Как выяснилось, практика японцев #227 не такая уж и хорошая. Рефакторинг метода DocumentParser::getLoginUserID() в PR dmi3yy/modx.evo.custom#230 позволяет методу всегда возвращать какие-то данные. Вот только логика как была кривая, так и осталась.

Для примера, если пользователь авторизован как web-юзер и никак иначе, то код
```php
$modx->getLoginUserID('mgr') === $modx->getLoginUserID('web')
```
Что как-бы по определению глупо. Это же самое касается и метода getLoginUserName. Т.е. получается нельзя вот так просто взять и проверить - авторизован ли пользователь как админ - или нет. Необходимо чекать сессию напрямую, что не есть хорошо:-)