### PR TITLE
Рефакторинг процессора move_document

### DIFF
--- a/install/setup.sql
+++ b/install/setup.sql
@@ -954,6 +954,8 @@ REPLACE INTO `{PREFIX}system_eventnames`
 ('31','OnDocFormSave','1','Documents'),
 ('32','OnBeforeDocFormDelete','1','Documents'),
 ('33','OnDocFormDelete','1','Documents'),
+('1034','onBeforeMoveDocument','1','Documents'),
+('1035','onAfterMoveDocument','1','Documents'),
 ('34','OnPluginFormPrerender','1','Plugins'),
 ('35','OnPluginFormRender','1','Plugins'),
 ('36','OnBeforePluginFormSave','1','Plugins'),

--- a/manager/processors/move_document.processor.php
+++ b/manager/processors/move_document.processor.php
@@ -4,28 +4,23 @@ if(!$modx->hasPermission('edit_document')) {
 	$modx->webAlertAndQuit($_lang["error_no_privileges"]);
 }
 
+$newParentID = isset($_REQUEST['new_parent']) ? (int)$_REQUEST['new_parent'] : 0;
+$documentID = isset($_REQUEST['id']) ? (int)$_REQUEST['id'] : 0;
+
 // ok, two things to check.
 // first, document cannot be moved to itself
 // second, new parent must be a folder. If not, set it to folder.
-if($_REQUEST['id']==$_REQUEST['new_parent']) {
-		$modx->webAlertAndQuit($_lang["error_movedocument1"]);
-}
-if($_REQUEST['id']=="") {
-		$modx->webAlertAndQuit($_lang["error_movedocument2"]);
-}
-if($_REQUEST['new_parent']=="") {
-		$modx->webAlertAndQuit($_lang["error_movedocument2"]);
-}
+if($documentID==$newParentID) $modx->webAlertAndQuit($_lang["error_movedocument1"]);
+if($documentID <= 0) $modx->webAlertAndQuit($_lang["error_movedocument2"]);
+if($newParentID <= 0) $modx->webAlertAndQuit($_lang["error_movedocument2"]);
 
-$rs = $modx->db->select('parent', $modx->getFullTableName('site_content'), "id='{$_REQUEST['id']}'");
-
+$rs = $modx->db->select('parent', $modx->getFullTableName('site_content'), "id='{$documentID}'");
 $oldparent = $modx->db->getValue($rs);
-$newParentID = $_REQUEST['new_parent'];
 
 // check user has permission to move document to chosen location
 
 if ($use_udperms == 1) {
-if ($oldparent != $newParentID) {
+	if ($oldparent != $newParentID) {
 		include_once MODX_MANAGER_PATH . "processors/user_documents_permissions.class.php";
 		$udperms = new udperms();
 		$udperms->user = $modx->getLoginUserID();
@@ -42,45 +37,58 @@ function allChildren($currDocID) {
 	global $modx;
 	$children= array();
 	$rs = $modx->db->select('id', $modx->getFullTableName('site_content'), "parent = '{$currDocID}'");
-			while ($child= $modx->db->getRow($rs)) {
-				$children[]= $child['id'];
-				$nextgen= array();
-				$nextgen= allChildren($child['id']);
-				$children= array_merge($children, $nextgen);
-			}
+	while ($child= $modx->db->getRow($rs)) {
+		$children[]= $child['id'];
+		$nextgen= array();
+		$nextgen= allChildren($child['id']);
+		$children= array_merge($children, $nextgen);
+	}
 	return $children;
 }
 
-$children= allChildren($_REQUEST['id']);
+$evtOut = $modx->invokeEvent("onBeforeMoveDocument", array (
+	"oldparent" => $oldparent,
+	"newparent" => $newParentID
+));
+if (is_array($evtOut) && count($evtOut) > 0){
+	$newParent = array_pop($evtOut);
+	if($newParent == $oldparent) {
+		$modx->webAlertAndQuit($_lang["error_movedocument2"]);
+	}else{
+		$newParentID = $newParent;
+	}
+}
 
+$children = allChildren($documentID);
 if (!array_search($newParentID, $children)) {
+	$modx->db->update(array(
+		'isfolder' => 1,
+	), $modx->getFullTableName('site_content'), "id='{$newParentID}'");
 
-	$modx->db->update(
-		array(
-			'isfolder' => 1,
-		), $modx->getFullTableName('site_content'), "id='{$_REQUEST['new_parent']}'");
-
-	$modx->db->update(
-		array(
-			'parent'   => $_REQUEST['new_parent'],
-			'editedby' => $modx->getLoginUserID(),
-			'editedon' => time(),
-		), $modx->getFullTableName('site_content'), "id='{$_REQUEST['id']}'");
+	$modx->db->update(array(
+		'parent'   => $newParentID,
+		'editedby' => $modx->getLoginUserID(),
+		'editedon' => time(),
+	), $modx->getFullTableName('site_content'), "id='{$documentID}'");
 
 	// finished moving the document, now check to see if the old_parent should no longer be a folder.
 	$rs = $modx->db->select('COUNT(*)', $modx->getFullTableName('site_content'), "parent='{$oldparent}'");
 	$limit = $modx->db->getValue($rs);
 
 	if(!$limit>0) {
-		$modx->db->update(
-			array(
-				'isfolder' => 0,
-			), $modx->getFullTableName('site_content'), "id='{$oldparent}'");
+		$modx->db->update(array(
+			'isfolder' => 0,
+		), $modx->getFullTableName('site_content'), "id='{$oldparent}'");
 	}
 
 	// Set the item name for logger
 	$pagetitle = $modx->db->getValue($modx->db->select('pagetitle', $modx->getFullTableName('site_content'), "id='{$id}'"));
 	$_SESSION['itemname'] = $pagetitle;
+
+	$modx->invokeEvent("onAfterMoveDocument", array (
+		"oldparent" => $oldparent,
+		"newparent" => $newParentID
+	));
 
 	// empty cache & sync site
 	$modx->clearCache('full');
@@ -90,4 +98,3 @@ if (!array_search($newParentID, $children)) {
 } else {
 	$modx->webAlertAndQuit("You cannot move a document to a child document!");
 }
-?>

--- a/manager/processors/move_document.processor.php
+++ b/manager/processors/move_document.processor.php
@@ -12,7 +12,7 @@ $documentID = isset($_REQUEST['id']) ? (int)$_REQUEST['id'] : 0;
 // second, new parent must be a folder. If not, set it to folder.
 if($documentID==$newParentID) $modx->webAlertAndQuit($_lang["error_movedocument1"]);
 if($documentID <= 0) $modx->webAlertAndQuit($_lang["error_movedocument2"]);
-if($newParentID <= 0) $modx->webAlertAndQuit($_lang["error_movedocument2"]);
+if($newParentID < 0) $modx->webAlertAndQuit($_lang["error_movedocument2"]);
 
 $rs = $modx->db->select('parent', $modx->getFullTableName('site_content'), "id='{$documentID}'");
 $oldparent = $modx->db->getValue($rs);

--- a/manager/processors/move_document.processor.php
+++ b/manager/processors/move_document.processor.php
@@ -47,8 +47,9 @@ function allChildren($currDocID) {
 }
 
 $evtOut = $modx->invokeEvent("onBeforeMoveDocument", array (
-	"oldparent" => $oldparent,
-	"newparent" => $newParentID
+	"id_document" => $documentID,
+	"old_parent" => $oldparent,
+	"new_parent" => $newParentID
 ));
 if (is_array($evtOut) && count($evtOut) > 0){
 	$newParent = array_pop($evtOut);
@@ -80,20 +81,20 @@ if (!array_search($newParentID, $children)) {
 			'isfolder' => 0,
 		), $modx->getFullTableName('site_content'), "id='{$oldparent}'");
 	}
-
 	// Set the item name for logger
-	$pagetitle = $modx->db->getValue($modx->db->select('pagetitle', $modx->getFullTableName('site_content'), "id='{$id}'"));
+	$pagetitle = $modx->db->getValue($modx->db->select('pagetitle', $modx->getFullTableName('site_content'), "id='{$documentID}'"));
 	$_SESSION['itemname'] = $pagetitle;
 
 	$modx->invokeEvent("onAfterMoveDocument", array (
-		"oldparent" => $oldparent,
-		"newparent" => $newParentID
+		"id_document" => $documentID,
+		"old_parent" => $oldparent,
+		"new_parent" => $newParentID
 	));
 
 	// empty cache & sync site
 	$modx->clearCache('full');
 
-	$header="Location: index.php?r=1&id=$id&a=7";
+	$header="Location: index.php?r=1&id={$documentID}&a=7";
 	header($header);
 } else {
 	$modx->webAlertAndQuit("You cannot move a document to a child document!");


### PR DESCRIPTION
- Рефакторинг процессора move_document.processor.php и добавление новых событий.
- Новое событие onBeforeMoveDocument
- Новое событие onAfterMoveDocument

**Пример использования onBeforeMoveDocument**
Контроль над перемещаемыми документами (отмена перемещения, подмена родителя и т.п.). _К сожалению, поддерживается только 1 плагин на данном событии._

``` php
//Для всех документов перемещаемых в корень или для документа с ID = 666
if($new_parent == 0 || $id_document==666){
    $modx->event->output($old_parent); //Отменить перемещение
    $modx->event->output(10); //Перенаправляем в папку с ID = 10
}
```

Область применения события **onAfterMoveDocument** (_результат работы плагин-а/ов никак не обрабатывается и не влияет на логику работы базового процессора_) более обширная:
- Сброс кастомного кеша
- Обновление сведений во вспомогательных таблицах (например, число дочерних документов)
