### PR TITLE
list-multi в параметрах

### DIFF
--- a/manager/includes/document.parser.class.inc.php
+++ b/manager/includes/document.parser.class.inc.php
@@ -3722,9 +3722,15 @@ class DocumentParser {
                     $pvTmp= explode(";", trim($pTmp[1]));
                     if ($pvTmp[1] == 'list' && $pvTmp[3] != "")
                         $parameter[trim($pTmp[0])]= $pvTmp[3]; //list default
-                    else
-                        if ($pvTmp[1] != 'list' && $pvTmp[2] != "")
-                            $parameter[trim($pTmp[0])]= $pvTmp[2];
+                    else {
+                        if($pvTmp[1] == 'list-multi') 
+				$parameter[trim($pTmp[0])]= $pvTmp[3]; // list-multi
+			else{
+				if ($pvTmp[1] != 'list' && $pvTmp[2] != ""){
+					$parameter[trim($pTmp[0])]= $pvTmp[2];
+				}
+			}
+                    }
                 }
             }
         }


### PR DESCRIPTION
Не верно передавались параметры, если параметр являлся типом list-multi. Передавались все дефолтные значения. Выбор игнорировался.
Данная правка исключает данный баг.