### PR TITLE
Использование mysqli_info

### DIFF
--- a/manager/includes/extenders/dbapi.mysqli.class.inc.php
+++ b/manager/includes/extenders/dbapi.mysqli.class.inc.php
@@ -60,6 +60,7 @@ class DBAPI {
 			$this->isConnected = true;
 			$modx->queryTime += $totaltime;
 		}
+		return $this->conn;
 	}
 
 	function disconnect() {


### PR DESCRIPTION
нужно передавать ссылку на подключение
mysqli_info($modx->db->connect())

mysqli_info например используется в modx.ddtools.class.php  в функции updateDocument примерно 482 строка

Может есть способ более лучший и правильный? то подскажите какой