### PR TITLE
Fix render properties menu

### DIFF
--- a/manager/actions/mutate_plugin.dynamic.php
+++ b/manager/actions/mutate_plugin.dynamic.php
@@ -42,6 +42,7 @@ if(isset($_GET['id']))
     {
         $modx->webAlertAndQuit($_lang["error_no_privileges"]);
     }
+    $content['properties'] = str_replace("&", "&amp;", $content['properties']);
 }
 else
 {
@@ -106,7 +107,7 @@ function showParameters(ctrl) {
             value = decode((ar[2])? ar[2]:'');
 
             // store values for later retrieval
-            if (key && (dt=='list' || dt=='list-multi')) currentParams[key] = [desc,dt,value,ar[3]];
+            if (key && (dt=='menu' || dt=='list' || dt=='list-multi')) currentParams[key] = [desc,dt,value,ar[3]];
             else if (key) currentParams[key] = [desc,dt,value];
 
             if (dt) {


### PR DESCRIPTION
При рендере параметров типа menu стиралось выбранное значение.
```
Добавлена замена & на &amp;
```