### PR TITLE
Fix render properties menu

### DIFF
--- a/manager/actions/mutate_snippet.dynamic.php
+++ b/manager/actions/mutate_snippet.dynamic.php
@@ -42,6 +42,7 @@ if(isset($_GET['id'])) {
     if($content['locked']==1 && $_SESSION['mgrRole']!=1) {
         $modx->webAlertAndQuit($_lang["error_no_privileges"]);
     }
+    $content['properties'] = str_replace("&", "&amp;", $content['properties']);
 } else {
     $_SESSION['itemname']=$_lang["new_snippet"];
 }
@@ -104,7 +105,7 @@ function showParameters(ctrl) {
             value = decode((ar[2])? ar[2]:'');
 
             // store values for later retrieval
-            if (key && dt=='list' || dt=='list-multi') currentParams[key] = [desc,dt,value,ar[3]];
+            if (key && dt=='menu' ||dt=='list' || dt=='list-multi') currentParams[key] = [desc,dt,value,ar[3]];
             else if (key) currentParams[key] = [desc,dt,value];
 
             if (dt) {


### PR DESCRIPTION
При рендере параметров типа menu стиралось выбранное значение.
```
Добавлена замена & на &amp;
```