### PR TITLE
Добавление плейсхолдера для вывода menuindex

### DIFF
--- a/assets/snippets/wayfinder/wayfinder.inc.php
+++ b/assets/snippets/wayfinder/wayfinder.inc.php
@@ -39,6 +39,7 @@ class Wayfinder {
 				'[+wf.description+]',
 				'[+wf.subitemcount+]',
 				'[+wf.refid+]',
+				'[+wf.menuindex+]',
 		'[+wf.iterator+]'
 			),
 			'wrapperLevel' => array(


### PR DESCRIPTION
В выборке строка 434 достается поле menuindex, а плейсхолдера для вывода нет. Иногда нужен.