### PR TITLE
Update protect.inc.php

### DIFF
--- a/manager/includes/protect.inc.php
+++ b/manager/includes/protect.inc.php
@@ -60,7 +60,7 @@ function getSanitizedValue($value='') {
     }
 
 modx_sanitize_gpc($_GET);
-if (!defined('IN_MANAGER_MODE') || (defined('IN_MANAGER_MODE') && (!IN_MANAGER_MODE || IN_MANAGER_MODE == 'false'))) {
+if (!defined('IN_MANAGER_MODE') || (defined('IN_MANAGER_MODE') && (!IN_MANAGER_MODE || IN_MANAGER_MODE === 'false'))) {
     modx_sanitize_gpc($_POST);
 }
 modx_sanitize_gpc($_COOKIE);


### PR DESCRIPTION
Отключение санитизации в своих дополнениях указанием define('IN_MANAGER_MODE', true); **не работало** из-за этого:  IN_MANAGER_MODE == 'false'

Приходилось писать define('IN_MANAGER_MODE', 'true'); //задавать true как строку

Замена на "==" на тождественное равенство позволит сохранить обратную совместимость и в то же время использовать логически верное define('IN_MANAGER_MODE', true); //true как boolean

Обсуждалось здесь http://modx.im/blog/questions/4798.html